### PR TITLE
feat/search params

### DIFF
--- a/packages/app/src/Aplication/Hooks/useDebounce.ts
+++ b/packages/app/src/Aplication/Hooks/useDebounce.ts
@@ -1,5 +1,13 @@
 import { useState, useEffect } from 'react';
 
+/**
+ * This hook waits for the delay time to change its own state value. If this value does not change, it does not return a new value.
+ *
+ * @template T
+ * @param {T} value
+ * @param {number} [delay=400]
+ * @returns {T}
+ */
 export const useDebounce = <T>(value: T, delay: number = 400): T => {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
@@ -8,7 +16,7 @@ export const useDebounce = <T>(value: T, delay: number = 400): T => {
       setDebouncedValue(value);
     }, delay);
 
-    // Limpiamos el timeout si el efecto se vuelve a ejecutar antes de que se complete
+    // This clear the timeout if the effect run again before this complete.
     return () => {
       clearTimeout(handler);
     };

--- a/packages/app/src/Aplication/Hooks/useDebounce.ts
+++ b/packages/app/src/Aplication/Hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+export const useDebounce = <T>(value: T, delay: number = 400): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Limpiamos el timeout si el efecto se vuelve a ejecutar antes de que se complete
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};

--- a/packages/app/src/Aplication/Hooks/useURLParams.ts
+++ b/packages/app/src/Aplication/Hooks/useURLParams.ts
@@ -1,22 +1,38 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useDebounce } from './useDebounce';
 
+/**
+ * This hook returns searchParams as an Object format and methods to update them.
+ * You can use searchParams to get an object.
+ * updateDebouncedParams use this method to update with delay.
+ * updateDebouncedParams, use this method to update with out delay.
+ *
+ * @template {Record<string, string>} TParams
+ * @param {?string} [baseURL] example '/catalog
+ * @param {number} [debounceTime=300]
+ * @returns {{ searchParams: any; updateDebouncedParams: any; updateParams: any; }}
+ */
 export const useURLParams = <TParams extends Record<string, string>>(
   baseURL?: string,
   debounceTime: number = 300,
 ) => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  // Define a new state than change from the component.
   const [urlSearchParams, updateDebouncedParams] = useState<
     Partial<Record<keyof TParams, string>>
   >({});
+  // Send this value to debounce hook.
   const debouncedValue = useDebounce(urlSearchParams, debounceTime);
 
   const updateParams = useCallback(
     (params: Partial<Record<keyof TParams, string>>) => {
+      // Get a new searchParams
       const newSearchParams = new URLSearchParams(searchParams);
-
+      /** This verify the values of each keys. If the the value exists, 
+      update the key else if the value doesn't exist, delete the key.
+      */
       Object.entries(params).forEach(([key, value]) => {
         if (value) {
           newSearchParams.set(key, value as string);
@@ -24,21 +40,34 @@ export const useURLParams = <TParams extends Record<string, string>>(
           newSearchParams.delete(key);
         }
       });
-
+      /* navigate
+        Using navigate here updates the browser URL without reloading the page, 
+        which is crucial for maintaining application state and providing a smooth 
+        user experience.
+      */
       navigate(`${baseURL}?${newSearchParams.toString()}`, {
         replace: true,
       });
+      /* setSearchParams 
+        Updates the search parameters in the internal state of React Router.
+        Triggers a re-render of components that depend on these parameters.
+        Does not cause a full navigation like navigate does.
+      */
       setSearchParams(newSearchParams);
     },
     [baseURL, navigate, searchParams, setSearchParams],
   );
 
   useEffect(() => {
+    // This execution updates the parameters on every change of the debounce value.
     if (Object.keys(debouncedValue).length > 0) {
       updateParams(debouncedValue);
     }
   }, [debouncedValue, updateParams]);
 
+  /*
+    This code return undefined or an object with each searchParams if params exists
+  */
   const getSearchParams = useCallback(
     (): TParams | undefined =>
       searchParams.size === 0
@@ -47,13 +76,13 @@ export const useURLParams = <TParams extends Record<string, string>>(
     [searchParams],
   );
 
-  const memoizedSearchParams = useMemo(
-    () => getSearchParams(),
-    [getSearchParams],
-  );
-
+  /*
+    You can use searchParams to get an object.
+    updateDebouncedParams use this method to update with delay.
+    updateDebouncedParams, use this method to update with out delay.
+  */
   return {
-    searchParams: memoizedSearchParams,
+    searchParams: getSearchParams(),
     updateDebouncedParams,
     updateParams,
   };

--- a/packages/app/src/Aplication/Hooks/useURLParams.ts
+++ b/packages/app/src/Aplication/Hooks/useURLParams.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useDebounce } from './useDebounce';
+
+export const useURLParams = <TParams extends Record<string, string>>(
+  baseURL?: string,
+  debounceTime: number = 300,
+) => {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [urlSearchParams, updateDebouncedParams] = useState<
+    Partial<Record<keyof TParams, string>>
+  >({});
+  const debouncedValue = useDebounce(urlSearchParams, debounceTime);
+
+  const updateParams = useCallback(
+    (params: Partial<Record<keyof TParams, string>>) => {
+      const newSearchParams = new URLSearchParams(searchParams);
+
+      Object.entries(params).forEach(([key, value]) => {
+        if (value) {
+          newSearchParams.set(key, value as string);
+        } else {
+          newSearchParams.delete(key);
+        }
+      });
+
+      navigate(`${baseURL}?${newSearchParams.toString()}`, {
+        replace: true,
+      });
+      setSearchParams(newSearchParams);
+    },
+    [baseURL, navigate, searchParams, setSearchParams],
+  );
+
+  useEffect(() => {
+    if (Object.keys(debouncedValue).length > 0) {
+      updateParams(debouncedValue);
+    }
+  }, [debouncedValue, updateParams]);
+
+  const getSearchParams = useCallback(
+    (): TParams | undefined =>
+      searchParams.size === 0
+        ? undefined
+        : (Object.fromEntries(searchParams.entries()) as TParams),
+    [searchParams],
+  );
+
+  const memoizedSearchParams = useMemo(
+    () => getSearchParams(),
+    [getSearchParams],
+  );
+
+  return {
+    searchParams: memoizedSearchParams,
+    updateDebouncedParams,
+    updateParams,
+  };
+};

--- a/packages/app/src/Domains/Users/Components/SearchUser.tsx
+++ b/packages/app/src/Domains/Users/Components/SearchUser.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Input } from '@app/Aplication/Components/ui/input';
 import { Link, useMatch } from 'react-router-dom';
 import { OutletSheet } from '@app/Aplication/Components';
 import { Button } from '@app/Aplication/Components';
 
 import { USERS_ROUTE, USERS_SEARCH_DETAIL_ROUTE } from '../Users.routes';
+import { useURLParams } from '@app/Aplication/Hooks/useURLParams';
+import { TUserSearch } from '../User.entity';
 
 export const SearchUser = () => {
   const [userId, setUserId] = useState<string>('');
@@ -12,23 +14,45 @@ export const SearchUser = () => {
   const [isSheetOpen, setIsSheetOpen] = useState<boolean>(
     !!isInDetail || false,
   );
+  // Initialize URL update params.
+  const { searchParams, updateDebouncedParams } =
+    useURLParams<TUserSearch>(USERS_ROUTE);
+  const [filterSearch, setFilterSearch] = useState(
+    () => searchParams?.name || '',
+  );
 
   const to = (userId && USERS_SEARCH_DETAIL_ROUTE.replace(':id', userId)) || '';
 
+  const handleFilter = ({
+    target: { value },
+  }: React.ChangeEvent<HTMLInputElement>) => {
+    setFilterSearch(value);
+    // Update URL params when change input.
+    updateDebouncedParams({ name: value });
+  };
+
   return (
-    <div className="flex gap-4 items-stretch bg-white">
+    <div className="flex flex-auto gap-4 items-stretch bg-white">
       <Input
         type="text"
         name="search"
         id=""
         value={userId}
         onChange={({ target }) => setUserId(target.value)}
-        className="max-w-[300px]"
+        className="max-w-[100px] "
         placeholder="ID a buscar"
       />
       <Link to={to}>
         <Button>Search</Button>
       </Link>
+      <Input
+        className="flex-auto"
+        type="text"
+        name="filterName"
+        onChange={handleFilter}
+        value={filterSearch}
+        placeholder="Escribe para filtrar por nombre"
+      />
 
       <OutletSheet
         open={isSheetOpen}

--- a/packages/app/src/Domains/Users/Components/SearchUser.tsx
+++ b/packages/app/src/Domains/Users/Components/SearchUser.tsx
@@ -17,9 +17,7 @@ export const SearchUser = () => {
   // Initialize URL update params.
   const { searchParams, updateDebouncedParams } =
     useURLParams<TUserSearch>(USERS_ROUTE);
-  const [filterSearch, setFilterSearch] = useState(
-    () => searchParams?.name || '',
-  );
+  const [filterSearch, setFilterSearch] = useState(searchParams?.name || '');
 
   const to = (userId && USERS_SEARCH_DETAIL_ROUTE.replace(':id', userId)) || '';
 

--- a/packages/app/src/Domains/Users/Components/UsersDetailSearch.tsx
+++ b/packages/app/src/Domains/Users/Components/UsersDetailSearch.tsx
@@ -14,7 +14,7 @@ import { toast } from 'sonner';
 
 export const UsersDetailSearch = () => {
   const { id = '' } = useParams();
-  const { data, isError } = useGetUser(id);
+  const { currentUser, isError } = useGetUser(id);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -32,17 +32,17 @@ export const UsersDetailSearch = () => {
         <SheetTitle>Detalles de Usuario</SheetTitle>
         <SheetDescription>Solo puedes ver el detalle.</SheetDescription>
       </SheetHeader>
-      {data ? (
+      {currentUser ? (
         <Card className="p-4">
           <ul>
             <li>
-              <span>ID: </span> <span>{data.id}</span>
+              <span>ID: </span> <span>{currentUser.id}</span>
             </li>
             <li>
-              <span>Nombre: </span> <span>{data.name}</span>
+              <span>Nombre: </span> <span>{currentUser.name}</span>
             </li>
             <li>
-              <span>Mail: </span> <span>{data.mail}</span>
+              <span>Mail: </span> <span>{currentUser.mail}</span>
             </li>
           </ul>
         </Card>

--- a/packages/app/src/Domains/Users/Hooks/useGetUser.ts
+++ b/packages/app/src/Domains/Users/Hooks/useGetUser.ts
@@ -5,32 +5,31 @@ import { useCacheUsers } from './useCacheUsers';
 
 export const useGetUser = (id: string) => {
   const [currentUser, setCurrentUser] = useState<TUser | null>(null);
-  const queryProductDetail = UsersService.get.useQuery(id, {
+  const queryUserDetail = UsersService.get.useQuery(id, {
     enabled: false,
   });
   const cacheUsersList = useCacheUsers();
-  const { isFetched, isFetching, refetch } = queryProductDetail;
+  const { isFetched, isFetching, refetch } = queryUserDetail;
 
   // Extraemos los datos de la caché si es que existe.
-  const cachedProduct = useMemo(
-    () =>
-      cacheUsersList.getData()?.find((product) => product.id === id) || null,
+  const cachedUsers = useMemo(
+    () => cacheUsersList.getData()?.find((user) => user.id === id) || null,
     [cacheUsersList, id],
   );
 
   useEffect(() => {
-    // Si el producto está en caché, lo usamos, de lo contrario, hacemos fetch
-    if (cachedProduct) {
-      setCurrentUser(cachedProduct);
+    // Si el usuario está en caché, lo usamos, de lo contrario, hacemos fetch
+    if (cachedUsers) {
+      setCurrentUser(cachedUsers);
     } else if (!isFetching && !isFetched) {
       refetch().then((res) => {
         setCurrentUser(res.data || null);
       });
     }
-  }, [id, isFetching, isFetched, refetch, cachedProduct]);
+  }, [id, isFetching, isFetched, refetch, cachedUsers]);
 
   return {
     currentUser,
-    ...queryProductDetail,
+    ...queryUserDetail,
   };
 };

--- a/packages/app/src/Domains/Users/Hooks/useGetUsers.ts
+++ b/packages/app/src/Domains/Users/Hooks/useGetUsers.ts
@@ -1,3 +1,8 @@
+import { useURLParams } from '@app/Aplication/Hooks/useURLParams';
+import { TUserSearch } from '../User.entity';
 import { UsersService } from '../Users.service';
 
-export const useGetUsers = () => UsersService.getAll.useQuery();
+export const useGetUsers = () => {
+  const { searchParams } = useURLParams<TUserSearch>();
+  return UsersService.getAll.useQuery(searchParams);
+};

--- a/packages/app/src/Domains/Users/Pages/UsersList.page.tsx
+++ b/packages/app/src/Domains/Users/Pages/UsersList.page.tsx
@@ -5,7 +5,7 @@ export const UsersListPage = () => {
   return (
     <Page title="Página de Usuarios">
       <div className="flex flex-col items-start gap-2">
-        <div className="w-full flex justify-between">
+        <div className="w-full flex justify-between gap-4">
           <SearchUser />
           <NewUserButton />
         </div>

--- a/packages/app/src/Domains/Users/User.entity.ts
+++ b/packages/app/src/Domains/Users/User.entity.ts
@@ -3,3 +3,7 @@ export type TUser = {
   mail: string;
   name: string;
 };
+
+export type TUserSearch = {
+  name: string;
+};

--- a/packages/server/src/Application/Adapters/ExecuteService.ts
+++ b/packages/server/src/Application/Adapters/ExecuteService.ts
@@ -67,7 +67,7 @@ type TexecuteServiceAlone<TService> = ({
  * @param {TexecuteServiceAlone<TService>} service
  * @returns {({ ctx }: IRequestAlone) => unknown}
  * @this bind remember bind the service.
- * @example executeServiceAlone(this.usersService.getAllUsers.bind(this.usersService))
+ * @example executeServiceAlone(this.usersService.getUsers.bind(this.usersService))
  */
 
 export const executeServiceAlone = <TService>(

--- a/packages/server/src/Application/Interfaces/IUseCase.ts
+++ b/packages/server/src/Application/Interfaces/IUseCase.ts
@@ -1,10 +1,11 @@
 import { RequestContext } from '../Entities';
 
-interface IExecuteParams<TInput> {
-  input?: TInput;
-  requestContext: RequestContext;
-}
-
 export interface IUseCase<TOutput = void, TInput = unknown> {
-  execute({ input, requestContext }: IExecuteParams<TInput>): Promise<TOutput>;
+  execute({
+    input,
+    requestContext,
+  }: {
+    input?: TInput;
+    requestContext: RequestContext;
+  }): Promise<TOutput>;
 }

--- a/packages/server/src/domains/Users/Application/Users.service.ts
+++ b/packages/server/src/domains/Users/Application/Users.service.ts
@@ -24,8 +24,8 @@ export class UsersService {
     private readonly _updateUser: UpdateUser,
   ) {}
 
-  async getUsers({ requestContext }: IGetUsers): Promise<User[]> {
-    return executeUseCase({ useCase: this._getUsers, requestContext });
+  async getUsers({ input, requestContext }: IGetUsers): Promise<User[]> {
+    return executeUseCase({ useCase: this._getUsers, input, requestContext });
   }
 
   async registerUser({ input, requestContext }: IRegisterUser): Promise<User> {

--- a/packages/server/src/domains/Users/Domain/UseCases/GetUsers.usecase.ts
+++ b/packages/server/src/domains/Users/Domain/UseCases/GetUsers.usecase.ts
@@ -6,7 +6,10 @@ import { IGetUsers } from '../User.interfaces';
 export class GetUsers implements IUseCase<User[]> {
   constructor(private usersRepository: UserRepository) {}
 
-  async execute({ requestContext }: IGetUsers): Promise<User[]> {
-    return await this.usersRepository.getUsers({ requestContext });
+  async execute({ input, requestContext }: IGetUsers): Promise<User[]> {
+    return await this.usersRepository.getUsers({
+      filters: input,
+      requestContext,
+    });
   }
 }

--- a/packages/server/src/domains/Users/Domain/User.interfaces.ts
+++ b/packages/server/src/domains/Users/Domain/User.interfaces.ts
@@ -1,6 +1,10 @@
 import { IRequestContext } from '@server/Application';
 
-export interface IGetUsers extends IRequestContext {}
+export interface IGetUsers extends IRequestContext {
+  input?: {
+    name?: string;
+  };
+}
 export interface IRegisterUser extends IRequestContext {
   input: {
     mail: string;

--- a/packages/server/src/domains/Users/Domain/User.repository.ts
+++ b/packages/server/src/domains/Users/Domain/User.repository.ts
@@ -1,7 +1,11 @@
 import { IRequestContext } from '@server/Application';
 import { User } from './User.entity';
 
-export interface IGetUsersRepository extends IRequestContext {}
+export interface IGetUsersRepository extends IRequestContext {
+  filters?: {
+    name?: string;
+  };
+}
 export interface IRegisterUserRepository extends IRequestContext {
   user: User;
 }

--- a/packages/server/src/domains/Users/Infrastructure/Controllers/Users.controller.ts
+++ b/packages/server/src/domains/Users/Infrastructure/Controllers/Users.controller.ts
@@ -1,15 +1,21 @@
 import { procedure, protectedProcedure } from '@server/Infrastructure/trpc';
 import { UsersService } from '../../Application';
-import { executeService, executeServiceAlone } from '@server/Application';
+import { executeService } from '@server/Application';
 import z from 'zod';
 import { loggerContextInput } from '@server/utils/pino';
 
 export class UsersController {
   constructor(private usersService: UsersService) {}
 
-  getAllUsers = protectedProcedure.query(
-    executeServiceAlone(this.usersService.getUsers.bind(this.usersService)),
-  );
+  getUsers = protectedProcedure
+    .input(
+      z
+        .object({
+          name: z.string(),
+        })
+        .optional(),
+    )
+    .query(executeService(this.usersService.getUsers.bind(this.usersService)));
 
   getUser = protectedProcedure
     .input(z.string())

--- a/packages/server/src/domains/Users/Infrastructure/Database/Local.database.ts
+++ b/packages/server/src/domains/Users/Infrastructure/Database/Local.database.ts
@@ -1,10 +1,17 @@
 import { Users } from '@server/data';
 import { delay } from '@server/utils/Utils';
 
+type TGetUsersList = {
+  name?: string;
+};
+
 export class LocalDatabase {
-  getUsersList = async () => {
+  getUsersList = async (filters?: TGetUsersList) => {
     await delay();
-    return Users;
+    if (!filters?.name) return Users;
+    return Users.filter((user) =>
+      user.name.includes(filters?.name?.toLowerCase() || ''),
+    );
   };
 
   getUser = async (id: string) => {

--- a/packages/server/src/domains/Users/Infrastructure/Database/UsersRepository.implementation.localDB.ts
+++ b/packages/server/src/domains/Users/Infrastructure/Database/UsersRepository.implementation.localDB.ts
@@ -13,10 +13,13 @@ import { LocalDatabase } from '.';
 export class UsersRepositoryImplementation implements UserRepository {
   private Db = new LocalDatabase();
 
-  async getUsers({ requestContext }: IGetUsersRepository): Promise<User[]> {
+  async getUsers({
+    filters,
+    requestContext,
+  }: IGetUsersRepository): Promise<User[]> {
     // TODO: use requestContext to execte db
     console.log(requestContext);
-    const users = await this.Db.getUsersList();
+    const users = await this.Db.getUsersList(filters);
     return users.map(({ id, name, mail }) => new User(id, mail, name));
   }
 

--- a/packages/server/src/domains/Users/Infrastructure/Routes/UserRoutes.ts
+++ b/packages/server/src/domains/Users/Infrastructure/Routes/UserRoutes.ts
@@ -1,11 +1,11 @@
 import { usersController } from '../../user.app';
 
-const { getAllUsers, getUser, registerUser, deleteUser, updateUser } =
+const { getUsers, getUser, registerUser, deleteUser, updateUser } =
   usersController;
 
 export const UserRoutes = {
   users: {
-    getAll: getAllUsers,
+    getAll: getUsers,
     create: registerUser,
     get: getUser,
     delete: deleteUser,


### PR DESCRIPTION
## Actualizando los parámetros de la URL e internos de ReactRouterDom
Se agregó un hook para debounce, esto permite generar un delay en el cambio de un state. 
Se creó un hook para gestionar los searchParams y actualizar la url. 

Ambos combinados permiten actualizar y escuchar los cambios desde cualquier componente. 

Implementación: 

Primero obtenemos searchParams y el método para actualizar los parámetros del hook `useURLParams`
Luego inicializamos un sate con el valor de searchParams por si en la URL previamente estaba cargado un queryParam, así el input toma ese valor. 

https://github.com/NicoCroce/blendverse/blob/4e3de64ee1a370c853eeb57160da78ed0d9bb8f3/packages/app/src/Domains/Users/Components/SearchUser.tsx#L17-L20

Luego con cada cambio en el input actualizamos el valor del state y luego actualizamos los parámetros.

https://github.com/NicoCroce/blendverse/blob/f932849e711cf4c0d91d3a53c16bf6e19b63121d/packages/app/src/Domains/Users/Components/SearchUser.tsx#L26-L32

Eso es todo en cuanto a la actualización. 

## Escuchando los cambios de searchParams
Al obtener searchParams desde un componente o un hook, estamos renderizando nuevamente dicho componente, por lo que está escuchando cada cambio en la URL. 

https://github.com/NicoCroce/blendverse/blob/f932849e711cf4c0d91d3a53c16bf6e19b63121d/packages/app/src/Domains/Users/Hooks/useGetUsers.ts#L5-L8